### PR TITLE
docs: CLAUDE.mdにStatic Analysis Rulesを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,31 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - 過剰なコメントは**禁止**
 - 作業ログ的なコメントは**禁止**
 
+## Static Analysis Rules
+
+### TypeScript Type Checking
+
+- **lsmcp MCPサーバの利用を最優先してください**
+- lsmcpが使えない場合の代替手段
+  - **ファイル単位での型チェックを実行すること**
+  - 全体型チェックよりも、作業対象ファイルの型チェックを優先する
+  - ファイル単位での実行コマンド: `npx tsc --noEmit path/to/file.ts` または `npx tsc --noEmit path/to/file.tsx`
+  - プロジェクト全体の型チェック: `pnpm build` （必要な場合のみ使用）
+
+### Linting (OxLint + ESLint)
+
+- **ファイル単位でのLint実行を優先すること**
+- 全体lintingよりも、作業対象ファイルのlintingを優先する
+- ファイル単位での実行コマンド: `npx oxlint path/to/file.ts && npx eslint path/to/file.ts` または `npx oxlint path/to/file.tsx && npx eslint path/to/file.tsx`
+- プロジェクト全体のlinting: `pnpm lint` （必要な場合のみ使用）
+
+### Formatting (OxFmt + Prettier)
+
+- **ファイル単位でのフォーマット実行を優先すること**
+- TypeScript/JavaScript ファイル: `npx oxfmt path/to/file.ts --write` または `npx oxfmt path/to/file.tsx --write`
+- CSS ファイル: `npx prettier --write path/to/file.css`
+- プロジェクト全体のフォーマット: `pnpm format` （必要な場合のみ使用）
+
 ## Github Guidelines
 
 - `gh` コマンドを使用して issue や PR にアクセスすること
@@ -45,8 +70,8 @@ pnpm tauri build      # ネイティブアプリケーションビルド
 **フロントエンドからの呼び出し**:
 
 ```typescript
-import { invoke } from "@tauri-apps/api/core";
-const result = await invoke("command_name", { arg1: "value" });
+import { invoke } from '@tauri-apps/api/core';
+const result = await invoke('command_name', { arg1: 'value' });
 ```
 
 ## Testing Standards
@@ -63,20 +88,17 @@ const result = await invoke("command_name", { arg1: "value" });
 #### 各テストレベルの役割と優先順位
 
 1. **Static Analysis（静的解析）** - 基盤
-
    - TypeScript 型チェック、ESLint、Prettier
    - 基本的な構文エラーや型エラーを早期発見
    - コードの品質と一貫性を保証
 
 2. **Unit Tests（ユニットテスト）** - 限定的使用
-
    - 純粋な関数、ユーティリティ関数のテスト
    - ビジネスロジックのテスト（カスタム Hooks 等）
    - モック使用は最小限に抑制
    - 複雑な計算ロジックや独立した関数のみを対象
 
 3. **Integration Tests（インテグレーションテスト）** - **最重要**
-
    - **React コンポーネントのテスト - これが最も価値が高い**
    - 実際のユーザー操作をシミュレート
    - MSW を使用して API レスポンスをモック
@@ -135,7 +157,7 @@ const newArray = array.map((item) => transformItem(item));
 const updatedUser = { ...user, age: 30 };
 
 // オブジェクトのイミュータブルな更新
-const user = { name: "John", age: 25 };
+const user = { name: 'John', age: 25 };
 const updatedUser = { ...user, age: 26 };
 
 // 配列のイミュータブルな更新
@@ -152,9 +174,9 @@ const mappedItems = items.map((item) => item * 2);
 
 ```typescript
 // 良い例
-const userName = "John";
+const userName = 'John';
 const MAX_RETRIES = 3;
-const API_ENDPOINT = "https://api.example.com";
+const API_ENDPOINT = 'https://api.example.com';
 function calculateTotal(items) {
   /* ... */
 }
@@ -171,13 +193,13 @@ class UserRepository {
 ```typescript
 // 良い例
 const user = {
-  name: "John",
+  name: 'John',
   address: undefined, // 住所情報がない
 };
 const getValue = () => undefined; // 値が存在しない場合
 
 // DOM関連の例外的な使用
-const element = document.querySelector(".not-exist"); // null が返される可能性あり
+const element = document.querySelector('.not-exist'); // null が返される可能性あり
 if (element === null) {
   // DOM要素が存在しない場合の処理
 }
@@ -202,7 +224,7 @@ if (array.length === 0) {
   // 配列が空の場合の処理
 }
 
-if (text === "") {
+if (text === '') {
   // 文字列が空の場合の処理
 }
 
@@ -239,9 +261,9 @@ if (option.type === REVIEW_OPTION_TYPE.TEXT) {
 }
 
 export const REVIEW_SETTING_TYPE = Object.freeze({
-  BASIC: "basic",
-  DESIGN: "design",
-  PATTERN_TEST: "pattern_test",
+  BASIC: 'basic',
+  DESIGN: 'design',
+  PATTERN_TEST: 'pattern_test',
 });
 ```
 
@@ -316,7 +338,7 @@ const fetchUserData = async (id: string) => {
   if (!response.ok) {
     return {
       ok: false,
-      error: response.error || new Error("Failed to fetch user data"),
+      error: response.error || new Error('Failed to fetch user data'),
     };
   }
 
@@ -332,7 +354,7 @@ const fetchUserData = async (id: string) => {
 };
 
 // 使用例
-const result = await fetchUserData("123");
+const result = await fetchUserData('123');
 if (result.ok) {
   const userData = result.data;
   // 成功時の処理

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -48,6 +48,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "ashpd"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbdf310d77fd3aaee6ea2093db7011dc2d35d2eb3481e5607f1f8d942ed99df"
+dependencies = [
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.9.2",
+ "raw-window-handle",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "zbus",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,6 +806,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
  "bitflags 2.10.0",
+ "block2",
+ "libc",
  "objc2",
 ]
 
@@ -797,6 +820,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.113",
+]
+
+[[package]]
+name = "dlib"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+dependencies = [
+ "libloading",
 ]
 
 [[package]]
@@ -1926,6 +1958,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-deep-link",
+ "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-http",
  "tauri-plugin-opener",
@@ -3398,6 +3431,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
+dependencies = [
+ "ashpd",
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3564,6 +3622,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 2.0.113",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -4343,6 +4407,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-dialog"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "313f8138692ddc4a2127c4c9607d616a46f5c042e77b3722450866da0aad2f19"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.17",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-fs"
 version = "2.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4700,6 +4782,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -5230,6 +5313,66 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fee64194ccd96bf648f42a65a7e589547096dfa702f7cadef84347b66ad164f9"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e6faa537fbb6c186cb9f1d41f2f811a4120d1b57ec61f50da451a0c5122bec"
+dependencies = [
+ "bitflags 2.10.0",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baeda9ffbcfc8cd6ddaade385eaf2393bd2115a69523c735f12242353c3df4f3"
+dependencies = [
+ "bitflags 2.10.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5423e94b6a63e68e439803a3e153a9252d5ead12fd853334e2ad33997e3889e3"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6dbfc3ac5ef974c92a2235805cc0114033018ae1290a72e474aa8b28cbbdfd"
+dependencies = [
+ "dlib",
+ "log",
+ "pkg-config",
 ]
 
 [[package]]
@@ -5959,6 +6102,7 @@ dependencies = [
  "ordered-stream",
  "serde",
  "serde_repr",
+ "tokio",
  "tracing",
  "uds_windows",
  "uuid",
@@ -6091,6 +6235,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
+ "url",
  "winnow 0.7.14",
  "zvariant_derive",
  "zvariant_utils",


### PR DESCRIPTION
## 概要

CLAUDE.mdにStatic Analysis Rules（静的解析ルール）セクションを追加し、開発時の型チェック・リント・フォーマットの実行方法を明確化しました。

## 変更内容

- **lsmcp MCPサーバの優先使用**: TypeScript型チェックにlsmcp MCPサーバを最優先で使用
- **ファイル単位の静的解析**: 全体チェックよりもファイル単位での実行を推奨
  - TypeScript: `npx tsc --noEmit path/to/file.ts`
  - Linting: `npx oxlint path/to/file.ts && npx eslint path/to/file.ts`
  - Formatting: `npx oxfmt path/to/file.ts --write`
- **Cargo.lock更新**: tauri-plugin-dialog依存関係の解決

## 検証方法

- [ ] CLAUDE.mdが正しくレンダリングされることを確認
- [ ] 記載されたコマンドが実際に動作することを確認
- [ ] TypeScript型チェック: `npx tsc --noEmit src/main.tsx`
- [ ] Linting: `npx oxlint src/main.tsx && npx eslint src/main.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)